### PR TITLE
Removed plotly package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ fire>=0.2.1
 giotto-tda>=0.1.4
 seaborn==0.9.0
 matplotlib>=3.1.0
-plotly==4.4.1
+# plotly==4.4.1
 xgboost>=0.90
 sympy>=1.5


### PR DESCRIPTION
Current giotto-tda package requires plotly (>= 4.8.2). Having it will resulting pipenv to fail. Also that package already has plotly as one of its dependencies.